### PR TITLE
authenticate via token in user creation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ function getUser(token) {
       try {
         const authId = decoded.sub.split('|')[1];
         const user = await prisma.user({ authId });
-        resolve(user);
+        resolve({decoded, user});
       } catch (error) {
         reject(error);
       }
@@ -56,7 +56,7 @@ function getUser(token) {
 
 // the function that sets up the global context for each resolver, using the req
 const context = async ({ req }) => ({
-  user: await getUser(req.headers.authorization)
+  ...await getUser(req.headers.authorization)
 });
 
 // The ApolloServer constructor requires two parameters: your schema

--- a/src/resolvers/mutation.js
+++ b/src/resolvers/mutation.js
@@ -12,12 +12,12 @@ const mutationError = error => ({
 });
 
 const Mutation = {
-  async createUser(parent, { data }, { dataSources: { prisma } }, info) {
+  async createUser(parent, { data }, { dataSources: { prisma }, decoded }, info) {
     try {
-      const { sub, email, ...fields } = data;
-      const authId = sub.split('|')[1];
+      const authId = decoded.sub.split('|')[1];
       const userExists = await prisma.$exists.user({ authId });
       if (!userExists) {
+        const { email, ...fields } = data;
         const user = await prisma.createUser({ authId, ...fields });
         if (email)
           await prisma.createProfileField({


### PR DESCRIPTION
There was a vulnerability in sending fake user subs in each request. This fixes it by taking subs via the token passed in the authorization header.